### PR TITLE
Fix compile error: 'uint32_t' does not name a type

### DIFF
--- a/chunked_parser.hh
+++ b/chunked_parser.hh
@@ -6,6 +6,8 @@
 #include "body_parser.hh"
 #include "exception.hh"
 
+#include <cstdint>
+
 class ChunkedBodyParser : public BodyParser
 {
 private:

--- a/queued_packet.hh
+++ b/queued_packet.hh
@@ -4,6 +4,7 @@
 #define QUEUED_PACKET_HH
 
 #include <string>
+#include <cstdint>
 
 struct QueuedPacket
 {


### PR DESCRIPTION
This pull request addresses a compile error in the chunked_parser.hh file where the compiler is unable to recognize the uint32_t type.

```
chunked_parser.hh:15:5: error: ‘uint32_t’ does not name a type
   15 |     uint32_t get_chunk_size(const std::string & chunk_hdr) const;
      |     ^~~~~~~~
```