### PR TITLE
fix: allow iptables to run as root

### DIFF
--- a/system_runner.cc
+++ b/system_runner.cc
@@ -38,6 +38,7 @@ void run( const vector< string > & command, char *const envp[] )
 
     /* run with empty environment */
     ChildProcess command_process( [&] () {
+            setuid(geteuid());
             SystemCall( "execve", execve( &argv[ 0 ][ 0 ], &argv[ 0 ], envp ) );
             return EXIT_FAILURE;
         } );


### PR DESCRIPTION
Since iptables 1.8.8, it exits immediately with an error code of 111 if it finds that it was called as a setuid-to-root program.

This commit adds a setuid(geteuid()) call before executing iptables to ensure it runs with the correct privileges.

https://git.netfilter.org/iptables/commit/?id=ef7781eb1437a2d6fd37eb3567c599e3ea682b96